### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  # Enable version updates for Gradle dependencies
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "gradle"
+    reviewers:
+      - "garethjevans"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    reviewers:
+      - "garethjevans"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"


### PR DESCRIPTION
## Summary
- Add Dependabot configuration file to automate dependency updates

## Changes
This PR adds a `.github/dependabot.yml` configuration file that enables automatic dependency updates for:

### Gradle Dependencies
- Weekly updates on Mondays at 9:00 AM
- Up to 10 open PRs at a time
- Labeled with `dependencies` and `gradle`

### GitHub Actions
- Weekly updates on Mondays at 9:00 AM  
- Up to 5 open PRs at a time
- Labeled with `dependencies` and `github-actions`

## Benefits
- Keeps dependencies up-to-date automatically
- Improves security by updating vulnerable dependencies
- Reduces manual maintenance effort
- Provides consistent commit messages with `chore(deps)` prefix

## Test Plan
- [ ] Verify the Dependabot configuration is valid
- [ ] Monitor for Dependabot PRs after merge
- [ ] Review and merge any dependency update PRs created by Dependabot