### PR TITLE
Add .envrc and .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ bin/
 # Spring Boot
 application-local.yml
 application-local.properties
+
+# Environment variables
+.envrc
+.env


### PR DESCRIPTION
## Summary
- Add environment variable files to `.gitignore`

## Changes

### Updated .gitignore
Added a new section for environment variable files:
- **`.envrc`**: Used by [direnv](https://direnv.net/) for automatic environment variable management
- **`.env`**: Common environment variable file used by many tools and frameworks

## Rationale

### Security
Prevents accidentally committing sensitive information such as:
- API keys and secrets
- Database credentials
- OAuth client IDs and secrets
- Environment-specific configuration

### Best Practices
- Environment variables should be managed outside of version control
- Each developer/environment can have their own configuration
- Follows the [Twelve-Factor App](https://12factor.net/config) methodology

## Context
This is particularly important for the auth-adapter module which requires:
- `GITHUB_CLIENT_ID`
- `GITHUB_CLIENT_SECRET`

These values should be set in `.envrc` or `.env` files locally, not committed to the repository.

## Test Results
- [x] All tests pass successfully (`./gradlew test`)
- [x] No existing `.envrc` or `.env` files are tracked in the repository

## Impact
- **Breaking Change**: No
- **Security Enhancement**: Yes
- **Developer Experience**: Improved