### PR TITLE
Set Spring Security logging level to TRACE for both applications

### DIFF
--- a/applications/auth-adapter/src/main/resources/application.yml
+++ b/applications/auth-adapter/src/main/resources/application.yml
@@ -30,5 +30,5 @@ management:
 
 logging:
   level:
-    org.springframework.security: DEBUG
-    org.springframework.security.oauth2: DEBUG
+    org.springframework.security: TRACE
+    org.springframework.security.oauth2: TRACE

--- a/applications/test-app/src/main/resources/application.yml
+++ b/applications/test-app/src/main/resources/application.yml
@@ -30,5 +30,5 @@ management:
 
 logging:
   level:
-    org.springframework.security: DEBUG
-    org.springframework.security.oauth2: DEBUG
+    org.springframework.security: TRACE
+    org.springframework.security.oauth2: TRACE


### PR DESCRIPTION
## Summary
- Change Spring Security logging level from DEBUG to TRACE for both auth-adapter and test-app
- Enables the most detailed security debugging information

## Changes

### Auth Adapter (`application.yml`)
```yaml
logging:
  level:
    org.springframework.security: TRACE
    org.springframework.security.oauth2: TRACE
```

### Test App (`application.yml`)
```yaml
logging:
  level:
    org.springframework.security: TRACE
    org.springframework.security.oauth2: TRACE
```

## Benefits

### Enhanced Debugging
TRACE level logging provides comprehensive security information including:

1. **Authentication Flow**:
   - Complete filter chain execution details
   - Authentication provider decisions
   - Security context setup and propagation
   - Session management details

2. **OAuth2 Flows**:
   - Authorization code exchange details
   - Token request and response logging
   - Redirect URI processing
   - State parameter validation
   - PKCE (Proof Key for Code Exchange) details if used

3. **Authorization Decisions**:
   - Access decision voting details
   - Security expression evaluation
   - Method security processing
   - URL-based security matching

4. **Filter Chain Processing**:
   - Every security filter invocation
   - Filter ordering and execution
   - Request/response modifications
   - Exception handling in security filters

## Use Cases

### Development
- Understanding OAuth2 flow step-by-step
- Debugging authentication failures
- Verifying security configuration

### Troubleshooting
- Investigating token validation issues
- Tracking authorization code flow
- Identifying redirect URI mismatches
- Understanding why requests are being denied

### Learning
- See exactly how Spring Security processes requests
- Understand OAuth2 protocol implementation
- Learn security filter chain behavior

## Example Log Output

With TRACE logging enabled, you'll see detailed output like:

```
TRACE o.s.s.w.FilterChainProxy - Trying to match request against DefaultSecurityFilterChain
TRACE o.s.s.w.a.AnonymousAuthenticationFilter - Set SecurityContextHolder to anonymous SecurityContext
TRACE o.s.s.o.client.web.OAuth2AuthorizationRequestRedirectFilter - Did not match request to Ant [pattern='/oauth2/authorization/{registrationId}']
TRACE o.s.s.w.FilterChainProxy - Secured GET /
```

## Performance Considerations

⚠️ **Important Notes**:
- TRACE logging is **very verbose** and generates significant log output
- Should primarily be used in **development/testing environments**
- May impact performance due to extensive logging overhead
- Consider using DEBUG or INFO for production environments

## Testing

- [x] All tests pass successfully (`./gradlew test`)
- [x] Configuration syntax is valid
- [x] No breaking changes to application functionality

## Rollback

If TRACE logging is too verbose, you can easily change back to DEBUG or INFO:

```yaml
logging:
  level:
    org.springframework.security: DEBUG  # or INFO
    org.springframework.security.oauth2: DEBUG  # or INFO
```

Or set environment-specific profiles:
- `application-dev.yml` - TRACE for development
- `application-prod.yml` - INFO for production

## Documentation

The Spring Security logging levels are:
- **TRACE**: Most detailed, shows every security decision
- **DEBUG**: Detailed security processing information
- **INFO**: General security events
- **WARN**: Potential security issues
- **ERROR**: Security failures