### PR TITLE
Set unique session cookie names and use 127.0.0.1 for consistency

### DIFF
--- a/applications/auth-adapter/src/main/java/com/example/chained/auth/adapter/config/AuthorizationServerConfig.java
+++ b/applications/auth-adapter/src/main/java/com/example/chained/auth/adapter/config/AuthorizationServerConfig.java
@@ -127,13 +127,13 @@ public class AuthorizationServerConfig {
 
     @Bean
     public JwtDecoder jwtDecoder(JWKSource<SecurityContext> jwkSource) {
-        return NimbusJwtDecoder.withJwkSetUri("http://localhost:9000/oauth2/jwks").build();
+        return NimbusJwtDecoder.withJwkSetUri("http://127.0.0.1:9000/oauth2/jwks").build();
     }
 
     @Bean
     public AuthorizationServerSettings authorizationServerSettings() {
         return AuthorizationServerSettings.builder()
-                .issuer("http://localhost:9000")
+                .issuer("http://127.0.0.1:9000")
                 .build();
     }
 }

--- a/applications/auth-adapter/src/main/resources/application.yml
+++ b/applications/auth-adapter/src/main/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   application:
     name: auth-adapter
   
+  session:
+    cookie:
+      name: AUTH_ADAPTER_SESSION
+  
   security:
     oauth2:
       client:

--- a/applications/test-app/src/main/resources/application.yml
+++ b/applications/test-app/src/main/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   application:
     name: test-app
 
+  session:
+    cookie:
+      name: TEST_APP_SESSION
+
   security:
     oauth2:
       client:
@@ -17,7 +21,7 @@ spring:
               - read
         provider:
           auth-adapter:
-            issuer-uri: http://localhost:9000
+            issuer-uri: http://127.0.0.1:9000
 
 server:
   port: 8080


### PR DESCRIPTION
## Summary
- Configure unique session cookie names for each application to avoid JSESSIONID conflicts
- Use 127.0.0.1 instead of localhost for consistency across all configurations

## Problem

When running both auth-adapter and test-app on localhost, they both use the default `JSESSIONID` cookie name. This causes serious issues:

1. **Session Conflicts**: Both apps share the same cookie on localhost domain
2. **Unexpected Logouts**: One app's session can overwrite the other's
3. **Authentication State Confusion**: Sessions get mixed up between applications
4. **Auth Failures**: Users get logged out unexpectedly during OAuth2 flows

### Example Scenario
```
1. User logs into auth-adapter → Sets JSESSIONID cookie
2. User navigates to test-app → test-app sets its own JSESSIONID
3. Browser overwrites auth-adapter's JSESSIONID cookie
4. User returns to auth-adapter → Session is lost, forced to re-login
```

## Solution

### Unique Session Cookie Names

Configure `spring.session.cookie.name` for each application:

**Auth Adapter** (`application.yml`):
```yaml
spring:
  session:
    cookie:
      name: AUTH_ADAPTER_SESSION
```

**Test App** (`application.yml`):
```yaml
spring:
  session:
    cookie:
      name: TEST_APP_SESSION
```

### Use 127.0.0.1 for Consistency

Update all OAuth2 and authorization server URLs to use `127.0.0.1` instead of `localhost`:

**Auth Adapter** (`AuthorizationServerConfig.java`):
```java
// JwtDecoder
NimbusJwtDecoder.withJwkSetUri("http://127.0.0.1:9000/oauth2/jwks").build()

// AuthorizationServerSettings
AuthorizationServerSettings.builder()
    .issuer("http://127.0.0.1:9000")
    .build()
```

**Test App** (`application.yml`):
```yaml
spring:
  security:
    oauth2:
      client:
        provider:
          auth-adapter:
            issuer-uri: http://127.0.0.1:9000
```

## Changes Made

### Auth Adapter
1. **application.yml**:
   - Added `spring.session.cookie.name: AUTH_ADAPTER_SESSION`

2. **AuthorizationServerConfig.java**:
   - JwtDecoder JWK Set URI: `http://localhost:9000` → `http://127.0.0.1:9000`
   - Authorization Server issuer: `http://localhost:9000` → `http://127.0.0.1:9000`

### Test App
1. **application.yml**:
   - Added `spring.session.cookie.name: TEST_APP_SESSION`
   - OAuth2 provider issuer-uri: `http://localhost:9000` → `http://127.0.0.1:9000`

## Benefits

### Session Isolation
- ✅ Each application has its own independent session management
- ✅ No more session cookie conflicts
- ✅ Sessions don't interfere with each other

### Reliability
- ✅ Prevents unexpected logouts
- ✅ Maintains authentication state correctly
- ✅ OAuth2 flow works smoothly without interruptions

### Debugging
- ✅ Clear distinction between app sessions in browser DevTools
- ✅ Easy to identify which cookie belongs to which app
- ✅ Consistent URLs throughout configuration

### Browser Developer Tools View
Before (conflict):
```
Cookies for localhost:
- JSESSIONID: ABC123... (Which app does this belong to?)
```

After (no conflict):
```
Cookies for 127.0.0.1:
- AUTH_ADAPTER_SESSION: ABC123...
- TEST_APP_SESSION: XYZ789...
```

## Testing

- [x] All tests pass successfully (`./gradlew test`)
- [x] Configuration syntax validated
- [x] No breaking changes to functionality

## Verification

To verify the fix works:

1. Start both applications:
   ```bash
   ./gradlew :applications:auth-adapter:bootRun
   ./gradlew :applications:test-app:bootRun
   ```

2. Open browser DevTools (F12) → Application/Storage → Cookies

3. Navigate to http://127.0.0.1:9000 and http://127.0.0.1:8080

4. Verify you see two distinct cookies:
   - `AUTH_ADAPTER_SESSION` for auth-adapter
   - `TEST_APP_SESSION` for test-app

5. Test the OAuth2 flow - sessions should remain stable

## Additional Notes

### localhost vs 127.0.0.1
Using `127.0.0.1` instead of `localhost` provides:
- More consistent behavior across environments
- Better cookie isolation (some browsers treat them differently)
- Matches industry best practices for local development

### Cookie Configuration Options
Spring Boot's `spring.session.cookie` supports additional options:
- `domain`: Cookie domain (defaults to current domain)
- `path`: Cookie path (defaults to /)
- `max-age`: Cookie lifetime
- `secure`: HTTPS only flag
- `http-only`: JavaScript access prevention
- `same-site`: CSRF protection

For this fix, we only need to change the `name` property.

## Future Considerations

For production deployments:
- Use proper domain names instead of IP addresses
- Configure `spring.session.cookie.domain` appropriately
- Enable `secure` flag for HTTPS environments
- Consider `same-site` cookie attribute for CSRF protection