### PR TITLE
feat: allow session cookies to be set via HTTP

### DIFF
--- a/applications/auth-adapter/src/main/resources/application.yml
+++ b/applications/auth-adapter/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
   session:
     cookie:
       name: AUTH_ADAPTER_SESSION
+      secure: false
   
   security:
     oauth2:

--- a/applications/test-app/src/main/resources/application.yml
+++ b/applications/test-app/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
   session:
     cookie:
       name: TEST_APP_SESSION
+      secure: false
 
   security:
     oauth2:


### PR DESCRIPTION
## Summary
- Configure session cookies to allow HTTP transmission in both auth-adapter and test-app
- Set `spring.session.cookie.secure: false` for local development environments

## Changes
- Updated `applications/auth-adapter/src/main/resources/application.yml`
- Updated `applications/test-app/src/main/resources/application.yml`

## Test plan
- [ ] Start both applications locally
- [ ] Verify session cookies are properly set when accessing http://127.0.0.1:8080
- [ ] Verify authentication flow works correctly over HTTP
- [ ] Confirm cookies are transmitted and stored by the browser

## Notes
This configuration is intended for local development. In production environments, HTTPS should be used and this setting should be removed or set to `true`.