### PR TITLE
feat: Use real GitHub access token in JWT claims

### DIFF
--- a/applications/auth-adapter/src/main/java/com/example/chained/auth/adapter/config/PocAuthTokenCustomizer.java
+++ b/applications/auth-adapter/src/main/java/com/example/chained/auth/adapter/config/PocAuthTokenCustomizer.java
@@ -15,11 +15,9 @@ public class PocAuthTokenCustomizer implements OAuth2TokenCustomizer<JwtEncoding
   public void customize(JwtEncodingContext context) {
     // load the token from the db
     String accessToken =
-        (String)
-            context
-                .getAuthorization()
-                .getAttributes()
-                .get(PocOAuth2AuthorizationCodeRequestAuthenticationProvider.ACCESS_TOKEN_KEY);
+        context
+            .getAuthorization()
+            .getAttribute(PocOAuth2AuthorizationCodeRequestAuthenticationProvider.ACCESS_TOKEN_KEY);
     LOGGER.debug("XXXXXXXXXXX Loaded raw access token from attributes: {}", accessToken);
     context
         .getClaims()

--- a/applications/auth-adapter/src/main/resources/application.yml
+++ b/applications/auth-adapter/src/main/resources/application.yml
@@ -22,6 +22,7 @@ spring:
             scope:
               - user:email
               - read:user
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
         provider:
           test-auth-server:
             issuer-uri: http://127.0.0.1:9001
@@ -50,6 +51,6 @@ logging:
   level:
     root: INFO
     org.springframework: DEBUG
-    org.springframework.security: DEBUG
+    org.springframework.security: TRACE
     org.springframework.web.cors: DEBUG
     com.example.chained: DEBUG


### PR DESCRIPTION
## Summary

This PR replaces the fake/hardcoded GitHub access token with the **actual OAuth2 access token** obtained from the GitHub authentication flow. The JWT issued by auth-adapter now contains the real GitHub token that can be used to make authenticated API calls.

## Changes

### 1. OAuth2AuthorizedClientManager Configuration 🔧

**AuthorizationServerConfig**:
- Added `authorizedClientManager` bean to manage OAuth2 authorized clients
- Configured `OAuth2AuthorizedClientProvider` with authorization code grant type
- Injected `OAuth2AuthorizedClientManager` into security filter chain
- Reordered configuration: `oauth2Client` now comes before `oauth2AuthorizationServer`

```java
@Bean
public OAuth2AuthorizedClientManager authorizedClientManager(
        ClientRegistrationRepository clientRegistrationRepository,
        OAuth2AuthorizedClientRepository authorizedClientRepository) {
    OAuth2AuthorizedClientProvider authorizedClientProvider =
            OAuth2AuthorizedClientProviderBuilder.builder()
                    .authorizationCode()
                    .build();
    DefaultOAuth2AuthorizedClientManager authorizedClientManager =
            new DefaultOAuth2AuthorizedClientManager(
                    clientRegistrationRepository, authorizedClientRepository);
    authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider);
    return authorizedClientManager;
}
```

### 2. Real Token Retrieval 🎫

**PocOAuth2AuthorizationCodeRequestAuthenticationProvider**:
- Added `OAuth2AuthorizedClientManager` as constructor dependency with null checks
- Uses `authorizedClientManager` to authorize GitHub client
- Creates `OAuth2AuthorizeRequest` with "github" registration and authenticated principal
- Extracts **real** `OAuth2AccessToken` from authorized client
- Stores actual token value in authorization attributes

**Before** (fake token):
```java
.attributes(attr -> attr.put(ACCESS_TOKEN_KEY, "gho_sfsdfsdfsdfsdfsdfsdfsdfsdfsfd"))
```

**After** (real token):
```java
OAuth2AuthorizeRequest authorizeRequest = OAuth2AuthorizeRequest
        .withClientRegistrationId("github")
        .principal(SecurityContextHolder.getContext().getAuthentication())
        .build();
OAuth2AccessToken accessToken = this.authorizedClientManager.authorize(authorizeRequest).getAccessToken();

.attributes(attr -> attr.put(ACCESS_TOKEN_KEY, accessToken.getTokenValue()))
```

### 3. Simplified Token Customizer 🔄

**PocAuthTokenCustomizer**:
- Simplified access token retrieval using `getAttribute()` directly
- Removed unnecessary cast and intermediate `getAttributes().get()` call

### 4. Configuration Updates ⚙️

**application.yml**:
- Added explicit `redirect-uri` for GitHub client: `"{baseUrl}/login/oauth2/code/{registrationId}"`
- Increased Spring Security log level to `TRACE` for detailed debugging

## How It Works

### OAuth2 Flow Integration

1. **Test-Auth-Server Authentication**
   - User logs in to test-auth-server
   - Primary identity established

2. **GitHub Authentication**
   - User redirects to GitHub OAuth2 flow
   - User authorizes application
   - GitHub returns authorization code
   - `OAuth2AuthorizedClientManager` exchanges code for **real access token**
   - Token stored in `OAuth2AuthorizedClientRepository`

3. **Authorization Code Issuance**
   - Auth-adapter prepares to issue authorization code to test-app
   - `PocOAuth2AuthorizationCodeRequestAuthenticationProvider` intercepts
   - Creates `OAuth2AuthorizeRequest` for GitHub client
   - `OAuth2AuthorizedClientManager` retrieves authorized client
   - **Real GitHub access token extracted**
   - Token stored in `OAuth2Authorization` attributes

4. **JWT Token Customization**
   - Test-app exchanges authorization code for JWT
   - `PocAuthTokenCustomizer` retrieves token from authorization attributes
   - **Real GitHub access token** added to JWT as `raw_access_token` claim

5. **API Usage**
   - Test-app receives JWT with real GitHub token
   - Can make authenticated GitHub API calls
   - Token has proper expiration and scopes

## JWT Token Structure

The JWT now contains the **real GitHub access token**:

```json
{
  "sub": "testuser",
  "test_auth_server_sub": "testuser",
  "preferred_username": "testuser",
  "name": "Test User",
  "github_login": "johndoe",
  "github_name": "John Doe",
  "github_email": "john@example.com",
  "github_id": 12345,
  "github_avatar_url": "https://avatars.githubusercontent.com/u/12345?v=4",
  "github_access_token": "<real_github_token>",
  "raw_access_token": "<real_github_token>",
  "iss": "http://127.0.0.1:9000",
  "aud": "client"
}
```

## Benefits

✅ **Real Token** - JWT contains actual GitHub OAuth2 access token, not fake/hardcoded value  
✅ **API Integration** - Test-app can make real authenticated GitHub API calls  
✅ **Proper Expiration** - Token has real expiration managed by GitHub  
✅ **Correct Scopes** - Token respects GitHub OAuth scopes (user:email, read:user)  
✅ **OAuth2 Compliant** - Full integration with Spring Security OAuth2 client  
✅ **Secure Flow** - Token obtained through proper OAuth2 authorization flow  

## Security Considerations

✅ **OAuth2 Flow** - Token obtained through legitimate OAuth2 authorization code flow  
✅ **Scope Management** - Token only has permissions for granted scopes  
✅ **Expiration** - Token has proper expiration from GitHub  
✅ **Principal Association** - Token retrieved using authenticated principal  
✅ **Session Management** - Token stored in authorized client repository  

⚠️ **JWT Size** - Real tokens are similar length to fake tokens (~40-100 chars)  
⚠️ **Token Sensitivity** - Real token must be protected (HTTPS in production)  
⚠️ **Expiration Handling** - Applications should handle token expiration/revocation  

## Testing

### Manual Test Plan

1. **Complete chained authentication flow**:
   - ✅ Login to test-auth-server
   - ✅ Authorize GitHub
   - ✅ Redirect to test-app

2. **Verify JWT contains real token**:
   - ✅ View `/authenticated` page in test-app
   - ✅ Check decoded JWT claims table
   - ✅ Verify `raw_access_token` claim is present
   - ✅ Confirm token is NOT the fake value "gho_sfsdfsdfsdfsdfsdfsdfsdfsdfsfd"

3. **Test GitHub API call**:
   ```bash
   # Extract token from JWT
   TOKEN="<raw_access_token_from_jwt>"
   
   # Test real GitHub API call
   curl -H "Authorization: Bearer $TOKEN" \
        -H "Accept: application/vnd.github+json" \
        https://api.github.com/user
   ```
   - ✅ API call should succeed with real user data
   - ✅ Should NOT return 401 Unauthorized

4. **Review logs**:
   - ✅ Check for OAuth2AuthorizedClientManager activity
   - ✅ Verify token retrieval from authorized client
   - ✅ Confirm token added to authorization attributes

### Expected Results

✅ JWT `raw_access_token` claim contains real GitHub token starting with "gho_" or "ghp_"  
✅ GitHub API calls succeed with token  
✅ Token has proper expiration (check GitHub token settings)  
✅ Token respects granted scopes (user:email, read:user)  

## Configuration

### GitHub OAuth App

Ensure GitHub OAuth app has redirect URI configured:
```
http://127.0.0.1:9000/login/oauth2/code/github
```

### Environment Variables

Set GitHub client credentials:
```bash
export GITHUB_CLIENT_ID="your-github-client-id"
export GITHUB_CLIENT_SECRET="your-github-client-secret"
```

## Migration Notes

### From PR #25

This PR builds on PR #25 which added:
- `github_access_token` claim via `ChainedAuthTokenCustomizer`
- Comprehensive logging

This PR now adds:
- `raw_access_token` claim via `PocAuthTokenCustomizer`
- Real token instead of fake token

Both claims now contain the **same real GitHub access token**.

### Backwards Compatibility

⚠️ **Breaking Change**: Applications relying on the fake token value will break. Update any tests or code that check for `"gho_sfsdfsdfsdfsdfsdfsdfsdfsdfsfd"`.

## Files Changed

**Modified Files**:
- `AuthorizationServerConfig.java` - Added OAuth2AuthorizedClientManager bean
- `PocOAuth2AuthorizationCodeRequestAuthenticationProvider.java` - Real token retrieval
- `PocAuthTokenCustomizer.java` - Simplified token access
- `application.yml` - GitHub redirect URI and TRACE logging

**Statistics**:
- 4 files changed
- +59 additions
- -14 deletions

## Related PRs

- #25 - GitHub access token to JWT and comprehensive logging
- #24 - JWT claims display
- #23 - Login integration tests

## Next Steps

After merging:
- [ ] Update documentation to reflect real token usage
- [ ] Add integration tests for real token retrieval
- [ ] Consider adding token refresh logic
- [ ] Monitor token expiration in production